### PR TITLE
feat: 뉴스 화면 및 관련 네비게이션 추가

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -13,6 +13,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import CustomTabBar from "./CustomTabBar";
 import { TouchableOpacity, Text } from "react-native";
 import profile from "./profile";
+import NewsScreen from "./NewsScreen";
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -30,6 +31,8 @@ function BackButton() {
 }
 // 메뉴바 포함 화면 (Home, Result, Predict, Ranking, MultiChart)
 function MainTabs() {
+  const Stack = createStackNavigator();
+
   return (
     <Tab.Navigator
       tabBar={(props) => <CustomTabBar {...props} />}
@@ -37,23 +40,38 @@ function MainTabs() {
         headerTitleAlign: "center",
       }}
     >
-      <Tab.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{
-          headerShown: false, // Home 화면에는 헤더를 숨김
-        }}
-      />
-
+      {/* 홈 화면 */}
+      <Tab.Screen name="Home" options={{ headerShown: false }}>
+        {() => (
+          <Stack.Navigator screenOptions={{ headerShown: true }}>
+            <Stack.Screen
+              name="HomeTab"
+              component={HomeScreen}
+              options={{
+                headerShown: false, // 헤더를 숨김
+              }}
+            />
+            <Stack.Screen name="결과보기" component={ResultScreen} />
+            <Stack.Screen
+              name="오늘은 올라갈까 내려갈까?"
+              component={PredictScreen}
+            />
+            <Stack.Screen name="뉴스" component={NewsScreen} />
+          </Stack.Navigator>
+        )}
+      </Tab.Screen>
+      {/* 랭킹 화면 */}
       <Tab.Screen
         name="랭킹"
         component={Ranking}
         options={{
-          headerLeft: () => <BackButton />, // 커스텀 뒤로 가기 버튼 추가
+          headerLeft: () => <BackButton />,
         }}
       />
+      {/* 주식차트 화면 */}
       <Tab.Screen name="주식차트" component={MultiChartScreen} />
-      <Tab.Screen name="프로필" component={profile}/>
+      {/* 프로필 화면 */}
+      <Tab.Screen name="프로필" component={profile} />
     </Tab.Navigator>
   );
 }
@@ -65,13 +83,10 @@ export default function App() {
           initialRouteName="Login"
           screenOptions={{ headerShown: false }}
         >
+          {/* 로그인 페이지 */}
           <Stack.Screen name="Login" component={LoginScreen} />
+          {/* 로그인 이후 화면은 MainTabs를 사용 */}
           <Stack.Screen name="MainTabs" component={MainTabs} />
-          <Stack.Screen name="결과보기" component={ResultScreen} />
-          <Stack.Screen
-            name="오늘은 올라갈까 내려갈까?"
-            component={PredictScreen}
-          />
         </Stack.Navigator>
       </NavigationContainer>
     </Provider>

--- a/NewsScreen.jsx
+++ b/NewsScreen.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, StyleSheet, FlatList } from "react-native";
+
+const newsData = [
+  { id: "1", title: "아마존, 클라우드 시장 점유율 상승 전망", ticker: "AMZN" },
+  { id: "2", title: "아마존, 프라임 서비스 가입자 수 증가", ticker: "AMZN" },
+  { id: "3", title: "아마존, 드론 배송 서비스 확대 계획 발표", ticker: "AMZN" },
+  { id: "4", title: "아마존, 신규 물류 센터 건설 착수", ticker: "AMZN" },
+  { id: "5", title: "애플, 새로운 아이폰 출시 임박", ticker: "AAPL" },
+  { id: "6", title: "애플, 증강현실 헤드셋 개발 중", ticker: "AAPL" },
+  { id: "7", title: "애플, 새로운 M1 칩 공개", ticker: "AAPL" },
+  { id: "8", title: "애플, 자율주행 자동차 프로젝트 가속화", ticker: "AAPL" },
+  { id: "9", title: "구글, AI 연구 성과 발표", ticker: "GOOGL" },
+  { id: "10", title: "구글, 클라우드 사업 확장 계획 발표", ticker: "GOOGL" },
+  { id: "11", title: "구글, 새로운 안드로이드 버전 출시", ticker: "GOOGL" },
+  { id: "12", title: "구글, 유튜브 프리미엄 구독자 증가", ticker: "GOOGL" },
+  { id: "13", title: "메타, 메타버스 프로젝트 확대 계획 발표", ticker: "META" },
+  { id: "14", title: "메타, 개인정보 보호 정책 업데이트", ticker: "META" },
+  { id: "15", title: "메타, VR 헤드셋 신제품 출시 예정", ticker: "META" },
+  { id: "16", title: "메타, 광고 수익 증가 전망 발표", ticker: "META" },
+  {
+    id: "17",
+    title: "마이크로소프트, 차세대 윈도우 업데이트 공개",
+    ticker: "MSFT",
+  },
+  {
+    id: "18",
+    title: "마이크로소프트, 게임 패스 구독자 수 증가",
+    ticker: "MSFT",
+  },
+  {
+    id: "19",
+    title: "마이크로소프트, 클라우드 서비스 매출 급증",
+    ticker: "MSFT",
+  },
+  {
+    id: "20",
+    title: "마이크로소프트, 새로운 서피스 제품 발표",
+    ticker: "MSFT",
+  },
+  { id: "21", title: "엔비디아, GPU 신제품 출시 예정", ticker: "NVDA" },
+  { id: "22", title: "엔비디아, AI 칩 개발 계획 발표", ticker: "NVDA" },
+  { id: "23", title: "엔비디아, 데이터 센터 매출 성장", ticker: "NVDA" },
+  { id: "24", title: "엔비디아, 자율주행 기술 협력 강화", ticker: "NVDA" },
+];
+
+const NewsScreen = ({ route }) => {
+  const { stockTicker } = route.params; // stockTicker로 전달된 주식 정보
+  // 전달된 주식 ticker에 맞는 뉴스 필터링
+  const filteredNewsData = newsData.filter(
+    (news) => news.ticker === stockTicker
+  );
+  const renderItem = ({ item }) => (
+    <View style={styles.newsItem}>
+      <View style={styles.placeholderImage} />
+      <Text style={styles.newsTitle}>{item.title}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionTitle}>뉴스</Text>
+      <FlatList
+        data={filteredNewsData}
+        renderItem={renderItem}
+        keyExtractor={(item) => item.id}
+        numColumns={2}
+        contentContainerStyle={styles.listContainer}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    backgroundColor: "#fff",
+  },
+  sectionTitle: {
+    fontSize: 24,
+    fontWeight: "bold",
+    marginBottom: 16,
+  },
+  listContainer: {
+    paddingBottom: 20,
+  },
+  newsItem: {
+    flex: 1,
+    flexDirection: "column",
+    alignItems: "flex-start",
+    marginBottom: 16,
+    marginHorizontal: 8,
+    backgroundColor: "#f0f0f0",
+    padding: 10,
+    borderRadius: 8,
+  },
+  placeholderImage: {
+    width: "100%",
+    aspectRatio: 1,
+    backgroundColor: "#d0d0d0",
+    borderRadius: 4,
+    marginBottom: 8,
+  },
+  newsTitle: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+});
+
+export default NewsScreen;

--- a/PredictScreen.jsx
+++ b/PredictScreen.jsx
@@ -15,6 +15,7 @@ import Google from "./stock/Google.json";
 import Meta from "./stock/Meta.json";
 import Microsoft from "./stock/Microsoft.json";
 import Nvidia from "./stock/Nvidia.json";
+import { useNavigation } from "@react-navigation/native";
 
 const PredictScreen = ({ route }) => {
   const [closePrices, setClosePrices] = useState([]);
@@ -59,7 +60,7 @@ const PredictScreen = ({ route }) => {
     }
     return ""; // 빈 문자열로 출력되지 않도록
   });
-
+  const navigation = useNavigation();
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -74,7 +75,12 @@ const PredictScreen = ({ route }) => {
           <Text>Loading chart data...</Text>
         )}
       </View>
-      <TouchableOpacity style={styles.newsButton}>
+      <TouchableOpacity
+        style={styles.newsButton}
+        onPress={() =>
+          navigation.navigate("뉴스", { stockTicker: stock.ticker })
+        }
+      >
         <Text style={styles.newsButtonText}>뉴스 보러가기</Text>
       </TouchableOpacity>
       <View style={styles.actionButtons}>


### PR DESCRIPTION
App.jsx:

NewsScreen 컴포넌트를 추가하여 새로운 화면으로 연결.
기존 MainTabs에 StackNavigator 추가 및 관련 설정 업데이트.
불필요한 화면(Route) 제거 (결과보기, 오늘은 올라갈까 내려갈까?).
프로필 탭 추가.
PredictScreen.jsx:

useNavigation 훅 도입으로 네비게이션 기능 개선.
뉴스 보러가기 버튼 추가 및 클릭 시 뉴스 화면으로 이동 기능 구현.
NewsScreen.jsx:

새로운 NewsScreen 컴포넌트 파일 생성.
뉴스 데이터를 기반으로 리스트 렌더링 기능 구현.
주식 종목별 뉴스 표시를 위한 UI 및 스타일 정의.